### PR TITLE
feat: 비영업일 및 특정 시간 이전 조회 시 이전 영업일 데이터 조회 로직 추가

### DIFF
--- a/api/client.py
+++ b/api/client.py
@@ -24,25 +24,3 @@ class ExchangeRateClient:
             print(f"API 요청 중 오류 발생: {e}")
             return None
 
-
-if __name__ == "__main__":
-    AUTH_KEY = os.getenv("AUTH_KEY")  # .env 파일에서 AUTH_KEY 로드
-    if not AUTH_KEY:
-        print("AUTH_KEY 환경 변수가 설정되지 않았습니다. .env 파일을 확인해주세요.")
-        exit()
-
-    client = ExchangeRateClient(AUTH_KEY)
-
-    # 오늘 날짜로 테스트 (예: 2025-07-11)
-    import datetime
-    today = datetime.date.today().strftime("%Y%m%d")
-
-    print(f"오늘 날짜 ({today}) 환율 정보 요청...")
-    rates = client.get_exchange_rates(searchdate=today)
-
-    if rates:
-        print("API 응답:")
-        import json
-        print(json.dumps(rates, indent=4, ensure_ascii=False))
-    else:
-        print("환율 정보를 가져오지 못했습니다.")

--- a/core/exchange_rate_manager.py
+++ b/core/exchange_rate_manager.py
@@ -9,49 +9,38 @@ class ExchangeRateManager:
 
     def fetch_exchange_rates(self, searchdate: str = None) -> list[ExchangeRate]:
         if searchdate is None:
-            current_date = datetime.date.today()
-        else:
-            current_date = datetime.datetime.strptime(searchdate, "%Y%m%d").date()
+            searchdate = datetime.date.today().strftime("%Y%m%d")
 
-        max_retries = 7  # 최대 7일까지 이전 날짜를 시도 (주말 포함)
-        for _ in range(max_retries):
-            search_date_str = current_date.strftime("%Y%m%d")
-            raw_rates = self.client.get_exchange_rates(search_date_str)
-            
-            # API 응답이 유효한 경우 (None이 아니고 빈 리스트가 아닌 경우)
-            if raw_rates and not (len(raw_rates) == 1 and raw_rates[0].get('result') == 4): # result 4는 조회 결과 없음을 의미
-                self.exchange_rates = []
-                for rate_data in raw_rates:
-                    result = rate_data.get('result', 1)
-                    if result != 1:
-                        print(f"API 응답 오류: {rate_data.get('cur_nm', 'Unknown Currency')} - Result Code: {result}")
-                        continue
-                    try:
-                        rate = ExchangeRate(
-                            result=result,
-                            cur_unit=rate_data.get('cur_unit', ''),
-                            ttb=rate_data.get('ttb', ''),
-                            tts=rate_data.get('tts', ''),
-                            deal_bas_r=rate_data.get('deal_bas_r', ''),
-                            bkpr=rate_data.get('bkpr', ''),
-                            yy_efee_r=rate_data.get('yy_efee_r', ''),
-                            ten_dd_efee_r=rate_data.get('ten_dd_efee_r', ''),
-                            kftc_bkpr=rate_data.get('bkpr', ''),
-                            kftc_deal_bas_r=rate_data.get('kftc_deal_bas_r', ''),
-                            cur_nm=rate_data.get('cur_nm', '')
-                        )
-                        self.exchange_rates.append(rate)
-                    except TypeError as e:
-                        print(f"환율 데이터 파싱 오류: {e} - Data: {rate_data}")
-                if self.exchange_rates: # 파싱된 데이터가 있으면 반환
-                    return self.exchange_rates
-            
-            # 데이터가 없거나 오류 응답인 경우, 하루 전으로 날짜 변경
-            current_date -= datetime.timedelta(days=1)
-            print(f"데이터를 찾을 수 없습니다. 이전 날짜 {current_date.strftime('%Y%m%d')}로 재시도합니다.")
+        raw_rates = self.client.get_exchange_rates(searchdate)
+        self.exchange_rates = []
 
-        print("최대 재시도 횟수를 초과했습니다. 환율 정보를 가져오지 못했습니다.")
-        return []
+        if raw_rates:
+            for rate_data in raw_rates:
+                # API 응답에서 'result' 필드가 없는 경우 기본값 1 (성공)으로 처리
+                result = rate_data.get('result', 1)
+                # 'result'가 1이 아닌 경우 (오류) 해당 데이터는 파싱하지 않음
+                if result != 1:
+                    print(f"API 응답 오류: {rate_data.get('cur_nm', 'Unknown Currency')} - Result Code: {result}")
+                    continue
+
+                try:
+                    rate = ExchangeRate(
+                        result=result,
+                        cur_unit=rate_data.get('cur_unit', ''),
+                        ttb=rate_data.get('ttb', ''),
+                        tts=rate_data.get('tts', ''),
+                        deal_bas_r=rate_data.get('deal_bas_r', ''),
+                        bkpr=rate_data.get('bkpr', ''),
+                        yy_efee_r=rate_data.get('yy_efee_r', ''),
+                        ten_dd_efee_r=rate_data.get('ten_dd_efee_r', ''),
+                        kftc_bkpr=rate_data.get('bkpr', ''),
+                        kftc_deal_bas_r=rate_data.get('kftc_deal_bas_r', ''),
+                        cur_nm=rate_data.get('cur_nm', '')
+                    )
+                    self.exchange_rates.append(rate)
+                except TypeError as e:
+                    print(f"환율 데이터 파싱 오류: {e} - Data: {rate_data}")
+        return self.exchange_rates
 
     def get_exchange_rate_by_currency(self, currency_code: str) -> ExchangeRate | None:
         for rate in self.exchange_rates:

--- a/core/exchange_rate_manager.py
+++ b/core/exchange_rate_manager.py
@@ -61,26 +61,3 @@ class ExchangeRateManager:
 
     def get_all_exchange_rates(self) -> list[ExchangeRate]:
         return self.exchange_rates
-
-if __name__ == "__main__":
-    AUTH_KEY = "qxf4jMteliYvRPID4ELzuARpeFIJUuha"  # 발급받은 인증키
-    manager = ExchangeRateManager(AUTH_KEY)
-
-    print("환율 정보 가져오는 중...")
-    rates = manager.fetch_exchange_rates()
-
-    if rates:
-        print(f"총 {len(rates)}개의 환율 정보 로드 완료.")
-        # 예시: 미국 달러 정보 출력
-        usd_rate = manager.get_exchange_rate_by_currency("USD")
-        if usd_rate:
-            print(f"미국 달러 (USD) 매매 기준율: {usd_rate.deal_bas_r}")
-        else:
-            print("미국 달러 정보를 찾을 수 없습니다.")
-
-        # 모든 통화명 출력
-        print("\n모든 통화명:")
-        for rate in rates:
-            print(f"- {rate.cur_nm} ({rate.cur_unit})")
-    else:
-        print("환율 정보를 가져오지 못했습니다.")

--- a/core/exchange_rate_manager.py
+++ b/core/exchange_rate_manager.py
@@ -9,38 +9,49 @@ class ExchangeRateManager:
 
     def fetch_exchange_rates(self, searchdate: str = None) -> list[ExchangeRate]:
         if searchdate is None:
-            searchdate = datetime.date.today().strftime("%Y%m%d")
+            current_date = datetime.date.today()
+        else:
+            current_date = datetime.datetime.strptime(searchdate, "%Y%m%d").date()
 
-        raw_rates = self.client.get_exchange_rates(searchdate)
-        self.exchange_rates = []
+        max_retries = 7  # 최대 7일까지 이전 날짜를 시도 (주말 포함)
+        for _ in range(max_retries):
+            search_date_str = current_date.strftime("%Y%m%d")
+            raw_rates = self.client.get_exchange_rates(search_date_str)
+            
+            # API 응답이 유효한 경우 (None이 아니고 빈 리스트가 아닌 경우)
+            if raw_rates and not (len(raw_rates) == 1 and raw_rates[0].get('result') == 4): # result 4는 조회 결과 없음을 의미
+                self.exchange_rates = []
+                for rate_data in raw_rates:
+                    result = rate_data.get('result', 1)
+                    if result != 1:
+                        print(f"API 응답 오류: {rate_data.get('cur_nm', 'Unknown Currency')} - Result Code: {result}")
+                        continue
+                    try:
+                        rate = ExchangeRate(
+                            result=result,
+                            cur_unit=rate_data.get('cur_unit', ''),
+                            ttb=rate_data.get('ttb', ''),
+                            tts=rate_data.get('tts', ''),
+                            deal_bas_r=rate_data.get('deal_bas_r', ''),
+                            bkpr=rate_data.get('bkpr', ''),
+                            yy_efee_r=rate_data.get('yy_efee_r', ''),
+                            ten_dd_efee_r=rate_data.get('ten_dd_efee_r', ''),
+                            kftc_bkpr=rate_data.get('bkpr', ''),
+                            kftc_deal_bas_r=rate_data.get('kftc_deal_bas_r', ''),
+                            cur_nm=rate_data.get('cur_nm', '')
+                        )
+                        self.exchange_rates.append(rate)
+                    except TypeError as e:
+                        print(f"환율 데이터 파싱 오류: {e} - Data: {rate_data}")
+                if self.exchange_rates: # 파싱된 데이터가 있으면 반환
+                    return self.exchange_rates
+            
+            # 데이터가 없거나 오류 응답인 경우, 하루 전으로 날짜 변경
+            current_date -= datetime.timedelta(days=1)
+            print(f"데이터를 찾을 수 없습니다. 이전 날짜 {current_date.strftime('%Y%m%d')}로 재시도합니다.")
 
-        if raw_rates:
-            for rate_data in raw_rates:
-                # API 응답에서 'result' 필드가 없는 경우 기본값 1 (성공)으로 처리
-                result = rate_data.get('result', 1)
-                # 'result'가 1이 아닌 경우 (오류) 해당 데이터는 파싱하지 않음
-                if result != 1:
-                    print(f"API 응답 오류: {rate_data.get('cur_nm', 'Unknown Currency')} - Result Code: {result}")
-                    continue
-
-                try:
-                    rate = ExchangeRate(
-                        result=result,
-                        cur_unit=rate_data.get('cur_unit', ''),
-                        ttb=rate_data.get('ttb', ''),
-                        tts=rate_data.get('tts', ''),
-                        deal_bas_r=rate_data.get('deal_bas_r', ''),
-                        bkpr=rate_data.get('bkpr', ''),
-                        yy_efee_r=rate_data.get('yy_efee_r', ''),
-                        ten_dd_efee_r=rate_data.get('ten_dd_efee_r', ''),
-                        kftc_bkpr=rate_data.get('bkpr', ''),
-                        kftc_deal_bas_r=rate_data.get('kftc_deal_bas_r', ''),
-                        cur_nm=rate_data.get('cur_nm', '')
-                    )
-                    self.exchange_rates.append(rate)
-                except TypeError as e:
-                    print(f"환율 데이터 파싱 오류: {e} - Data: {rate_data}")
-        return self.exchange_rates
+        print("최대 재시도 횟수를 초과했습니다. 환율 정보를 가져오지 못했습니다.")
+        return []
 
     def get_exchange_rate_by_currency(self, currency_code: str) -> ExchangeRate | None:
         for rate in self.exchange_rates:


### PR DESCRIPTION
API에서 비영업일 또는 영업일 오전 11시 이전에 데이터를 요청할 경우 null 값이 반환되어 프로그램이 작동하지 않는 버그를 수정합니다.

- `ExchangeRateManager.fetch_exchange_rates` 함수에 재시도 로직을 추가하여, 유효한 데이터를 찾을 때까지 이전 날짜로 요청을 보냅니다.
- 최대 7일까지 이전 날짜를 탐색하여 주말 및 공휴일에도 데이터를 조회할 수 있도록 합니다.

closes #7